### PR TITLE
fix: sender validation, test registry address, add requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+out.blob
+.pytest_cache/

--- a/blob_encoder.py
+++ b/blob_encoder.py
@@ -26,9 +26,9 @@ def _parse_sender(sender: bytes | str) -> bytes:
     if isinstance(sender, str):
         if not sender.startswith("0x"):
             raise ValueError(f"string sender must be 0x-prefixed, got {sender!r}")
-        return bytes.fromhex(sender[2:])
+        sender = bytes.fromhex(sender[2:])
     if len(sender) != 20:
-        raise ValueError(f"bytes sender must be 20 bytes, got {len(sender)}")
+        raise ValueError(f"sender must be 20 bytes, got {len(sender)}")
     return sender
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+py_ecc>=7.0.0
+web3>=6.0.0
+vyper>=0.4.3
+pytest>=7.0.0
+eth-tester[py-evm]>=0.12.0

--- a/test.py
+++ b/test.py
@@ -115,9 +115,8 @@ print("Key registration complete")
 # Register blob on-chain and verify the event
 # ---------------------------------------------------------------------------
 
-ZERO_ADDR = Web3.to_checksum_address("0x" + "00" * 20)
 receipt = w3.eth.wait_for_transaction_receipt(
-    core.functions.registerCalldataBatch(blob, decoder.address, ZERO_ADDR)
+    core.functions.registerCalldataBatch(blob, decoder.address, registry.address)
         .transact({"from": deployer})
 )
 


### PR DESCRIPTION
## Summary

- **blob_encoder**: `_parse_sender` now validates hex string length after decoding (fixes #1). Previously a string like `"0xABCD"` produced 2 bytes instead of 20, silently corrupting the blob format. Unified the length check for both bytes and string input types.

- **test.py**: Pass `registry.address` instead of zero address to `registerCalldataBatch` (fixes #4). The `BlobBatchRegistered` event now logs the correct `signatureRegistry` address, matching the BAM protocol (ERC-8180) expectation for indexer discovery.

- Add `requirements.txt` with minimum version pins for all dependencies (fixes #5).

- Add `.gitignore` for `__pycache__/`, `out.blob`, `.pytest_cache/`.

## Test plan

- [ ] `python test.py` passes end-to-end
- [ ] `pytest hash_to_point_test.py -v` passes
- [ ] `_parse_sender("0xABCD")` now raises `ValueError` instead of returning 2 bytes
- [ ] `BlobBatchRegistered` event contains non-zero `signatureRegistry` address