### PR TITLE
feat: add BAM Core (ERC-8180/8179) and Exposer contracts

### DIFF
--- a/bam_core.vy
+++ b/bam_core.vy
@@ -1,0 +1,166 @@
+# @version ^0.4.3
+#
+# bam_core.vy -- IERC_BAM_Core (ERC-8180) extending IERC_BSS (ERC-8179).
+#
+# Implements the on-chain registration point for blob-authenticated messaging.
+# Aggregators and self-publishing users call registerBlobBatch or
+# registerCalldataBatch to declare that a batch exists. The core stores
+# batch registrations and emits events that indexers use to discover batches.
+#
+# BSS (ERC-8179) provides blob segment declaration with field element bounds.
+# BAM (ERC-8180) extends BSS with decoder and signature registry pointers.
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+MAX_FIELD_ELEMENTS: constant(uint16) = 4096
+MAX_BATCH_DATA: constant(uint256) = 131072  # 128 KiB max calldata batch
+
+# ── Events ───────────────────────────────────────────────────────────────────
+
+# ERC-8179 (BSS) event
+event BlobSegmentDeclared:
+    versionedHash: indexed(bytes32)
+    submitter:     indexed(address)
+    startFE:       uint16
+    endFE:         uint16
+    contentTag:    bytes32
+
+# ERC-8180 (BAM) events
+event BlobBatchRegistered:
+    versionedHash:     indexed(bytes32)
+    submitter:         indexed(address)
+    decoder:           indexed(address)
+    signatureRegistry: address
+
+event CalldataBatchRegistered:
+    contentHash:       indexed(bytes32)
+    submitter:         indexed(address)
+    decoder:           indexed(address)
+    signatureRegistry: address
+
+# ── Storage ──────────────────────────────────────────────────────────────────
+
+# Tracks registered batch content hashes (versioned hash or keccak256 of calldata).
+registered: public(HashMap[bytes32, bool])
+
+# ── BSS Interface (ERC-8179) ─────────────────────────────────────────────────
+
+@external
+def declareBlobSegment(blobIndex: uint256, startFE: uint16, endFE: uint16, contentTag: bytes32) -> bytes32:
+    """Declare a blob segment with field element bounds.
+
+    Validates segment coordinates and retrieves the versioned hash via BLOBHASH.
+    Emits BlobSegmentDeclared per ERC-8179.
+
+    Parameters:
+        blobIndex:  Index of the blob within the transaction (0-based).
+        startFE:    Start field element (inclusive). Must be < endFE.
+        endFE:      End field element (exclusive). Must be <= 4096.
+        contentTag: Protocol/content identifier.
+
+    Returns:
+        versionedHash: The EIP-4844 versioned hash of the blob.
+    """
+    assert startFE < endFE, "InvalidSegment: startFE >= endFE"
+    assert endFE <= MAX_FIELD_ELEMENTS, "InvalidSegment: endFE > 4096"
+
+    versionedHash: bytes32 = blobhash(blobIndex)
+    assert versionedHash != empty(bytes32), "NoBlobAtIndex"
+
+    log BlobSegmentDeclared(
+        versionedHash=versionedHash,
+        submitter=msg.sender,
+        startFE=startFE,
+        endFE=endFE,
+        contentTag=contentTag,
+    )
+    return versionedHash
+
+# ── BAM Core Interface (ERC-8180) ───────────────────────────────────────────
+
+@external
+def registerBlobBatch(
+    blobIndex: uint256,
+    startFE: uint16,
+    endFE: uint16,
+    contentTag: bytes32,
+    decoder: address,
+    signatureRegistry: address,
+) -> bytes32:
+    """Register a blob batch with segment coordinates, decoder, and signature registry.
+
+    Calls declareBlobSegment internally (BSS validation), then emits
+    BlobBatchRegistered. Stores the versioned hash as registered.
+
+    Parameters:
+        blobIndex:         Index of the blob within the transaction (0-based).
+        startFE:           Start field element (inclusive). Must be < endFE.
+        endFE:             End field element (exclusive). Must be <= 4096.
+        contentTag:        Protocol/content identifier.
+        decoder:           Decoder contract address for extracting messages.
+        signatureRegistry: Signature registry address for verifying signatures.
+
+    Returns:
+        versionedHash: The EIP-4844 versioned hash of the blob.
+    """
+    # BSS validation: segment bounds and BLOBHASH retrieval
+    assert startFE < endFE, "InvalidSegment: startFE >= endFE"
+    assert endFE <= MAX_FIELD_ELEMENTS, "InvalidSegment: endFE > 4096"
+
+    versionedHash: bytes32 = blobhash(blobIndex)
+    assert versionedHash != empty(bytes32), "NoBlobAtIndex"
+
+    # Emit BSS event first (per spec: declareBlobSegment before BlobBatchRegistered)
+    log BlobSegmentDeclared(
+        versionedHash=versionedHash,
+        submitter=msg.sender,
+        startFE=startFE,
+        endFE=endFE,
+        contentTag=contentTag,
+    )
+
+    # Record registration
+    self.registered[versionedHash] = True
+
+    # Emit BAM event
+    log BlobBatchRegistered(
+        versionedHash=versionedHash,
+        submitter=msg.sender,
+        decoder=decoder,
+        signatureRegistry=signatureRegistry,
+    )
+    return versionedHash
+
+
+@external
+def registerCalldataBatch(
+    batchData: Bytes[MAX_BATCH_DATA],
+    decoder: address,
+    signatureRegistry: address,
+) -> bytes32:
+    """Register a batch submitted via calldata.
+
+    Computes contentHash as keccak256(batchData), records it as registered,
+    and emits CalldataBatchRegistered.
+
+    Parameters:
+        batchData:         The batch payload bytes.
+        decoder:           Decoder contract address for extracting messages.
+        signatureRegistry: Signature registry address for verifying signatures.
+
+    Returns:
+        contentHash: The keccak256 hash of batchData.
+    """
+    contentHash: bytes32 = keccak256(batchData)
+
+    # Record registration
+    self.registered[contentHash] = True
+
+    # Emit BAM event
+    log CalldataBatchRegistered(
+        contentHash=contentHash,
+        submitter=msg.sender,
+        decoder=decoder,
+        signatureRegistry=signatureRegistry,
+    )
+    return contentHash

--- a/exposer.vy
+++ b/exposer.vy
@@ -1,0 +1,132 @@
+# @version ^0.4.3
+#
+# exposer.vy -- IERC_BAM_Exposer (ERC-8180).
+#
+# Proves individual messages on-chain from registered batches. Enables smart
+# contracts to react to specific messages (governance, token gates, disputes).
+#
+# Message ID: keccak256(abi.encodePacked(author, nonce, contentHash))
+#   - author:      message author's Ethereum address (20 bytes)
+#   - nonce:       per-author monotonically increasing counter (uint64, 8 bytes)
+#   - contentHash: batch identifier (bytes32, 32 bytes)
+#
+# The exposer checks that the batch was registered in the BAM Core contract,
+# prevents double-exposure, and emits MessageExposed for indexers.
+
+# ── Interfaces ───────────────────────────────────────────────────────────────
+
+interface BAMCore:
+    def registered(contentHash: bytes32) -> bool: view
+
+# ── Events ───────────────────────────────────────────────────────────────────
+
+event MessageExposed:
+    contentHash: indexed(bytes32)
+    messageId:   indexed(bytes32)
+    author:      indexed(address)
+    exposer:     address
+    timestamp:   uint64
+
+# ── Storage ──────────────────────────────────────────────────────────────────
+
+bamCore: public(address)
+exposed: public(HashMap[bytes32, bool])
+
+# ── Constructor ──────────────────────────────────────────────────────────────
+
+@deploy
+def __init__(bam_core: address):
+    """Initialize the exposer with a reference to the BAM Core contract.
+
+    Parameters:
+        bam_core: Address of the deployed BAM Core (ERC-8180) contract.
+    """
+    assert bam_core != empty(address), "InvalidCoreAddress"
+    self.bamCore = bam_core
+
+# ── View Functions ───────────────────────────────────────────────────────────
+
+@external
+@view
+def isExposed(messageId: bytes32) -> bool:
+    """Check whether a message has already been exposed.
+
+    Parameters:
+        messageId: The message ID to check.
+
+    Returns:
+        True if the message has been exposed, False otherwise.
+    """
+    return self.exposed[messageId]
+
+
+@external
+@pure
+def computeMessageId(author: address, nonce: uint64, contentHash: bytes32) -> bytes32:
+    """Compute the message ID per ERC-8180 convention.
+
+    messageId = keccak256(abi.encodePacked(author, nonce, contentHash))
+      - author:      20 bytes
+      - nonce:       8 bytes (uint64, big-endian)
+      - contentHash: 32 bytes
+
+    Parameters:
+        author:      The message author's Ethereum address.
+        nonce:       The per-author monotonically increasing nonce.
+        contentHash: The batch content hash (versioned hash or keccak256).
+
+    Returns:
+        The computed message ID.
+    """
+    return keccak256(
+        concat(
+            convert(author, bytes20),
+            convert(nonce, bytes8),
+            contentHash,
+        )
+    )
+
+# ── Exposure ─────────────────────────────────────────────────────────────────
+
+@external
+def exposeMessage(batchContentHash: bytes32, author: address, nonce: uint64, contentHash: bytes32):
+    """Prove that a specific message exists in a registered batch on-chain.
+
+    Verifies the batch is registered in the BAM Core contract, computes the
+    message ID, checks for double-exposure, records it, and emits
+    MessageExposed.
+
+    Parameters:
+        batchContentHash: The content hash of the registered batch
+                          (versioned hash for blobs, keccak256 for calldata).
+        author:           The message author's Ethereum address.
+        nonce:            The per-author monotonically increasing nonce.
+        contentHash:      The content hash used in the message ID computation.
+    """
+    # Verify the batch is registered in the BAM Core contract
+    isRegistered: bool = staticcall BAMCore(self.bamCore).registered(batchContentHash)
+    assert isRegistered, "NotRegistered"
+
+    # Compute message ID: keccak256(author || nonce || contentHash)
+    messageId: bytes32 = keccak256(
+        concat(
+            convert(author, bytes20),
+            convert(nonce, bytes8),
+            contentHash,
+        )
+    )
+
+    # Prevent double-exposure
+    assert not self.exposed[messageId], "AlreadyExposed"
+
+    # Record exposure
+    self.exposed[messageId] = True
+
+    # Emit event
+    log MessageExposed(
+        contentHash=batchContentHash,
+        messageId=messageId,
+        author=author,
+        exposer=msg.sender,
+        timestamp=convert(block.timestamp, uint64),
+    )


### PR DESCRIPTION
## Summary

- **`bam_core.vy`** -- Full `IERC_BAM_Core` (ERC-8180) extending `IERC_BSS` (ERC-8179): `declareBlobSegment` with BSS validation (startFE < endFE, endFE <= 4096), `registerBlobBatch` for EIP-4844 blob transactions (emits `BlobSegmentDeclared` + `BlobBatchRegistered`), and `registerCalldataBatch` for calldata-based batches (emits `CalldataBatchRegistered`). Stores batch registrations in a `contentHash -> bool` mapping for downstream verification by the exposer.
- **`exposer.vy`** -- `IERC_BAM_Exposer` (ERC-8180): `exposeMessage` proves individual messages on-chain with batch registration check (`NotRegistered` revert), double-exposure prevention (`AlreadyExposed` revert), and `MessageExposed` event emission. `isExposed` queries exposure status. `computeMessageId` implements `keccak256(author || nonce || contentHash)` per ERC-8180. Constructor takes the BAM Core contract address.

Both contracts use `# @version ^0.4.3` and follow the existing Vyper style in the repo.

## ERC Interface Coverage

| # | Interface | Contract | Status |
|---|-----------|----------|--------|
| 1 | `IERC_BAM_Decoder` | `decoder.vy` | Existing |
| 2 | `IERC_BAM_SignatureRegistry` | `signature_registry.vy` | Existing |
| 3 | `IERC_BSS` (ERC-8179) | `bam_core.vy` | **New** |
| 4 | `IERC_BAM_Core` (ERC-8180) | `bam_core.vy` | **New** |
| 5 | `IERC_BAM_Exposer` (ERC-8180) | `exposer.vy` | **New** |

## Test plan

All items verified via local pytest (19 tests in `test_erc_interfaces.py` from PR #11) and Sepolia on-chain testing (PR #13).

- [x] Verify `declareBlobSegment` reverts on `startFE >= endFE` and `endFE > 4096` — [Sepolia step 9](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `TestDeclareBlobSegment` (5 tests)
- [x] Verify `registerBlobBatch` validates BSS bounds (reverts on invalid segments) — local `TestRegisterBlobBatch` (3 tests)
- [x] Verify `registerBlobBatch` reverts with `NoBlobAtIndex` when no blob present — local `test_valid_bounds_reverts_on_no_blob`
- [x] Verify `registerCalldataBatch` computes `keccak256(batchData)` and emits `CalldataBatchRegistered` — [Sepolia tx `c6a569...`](https://sepolia.etherscan.io/tx/0xc6a56958e13de857ace13562278fa6d19fb250be007e29d6c6467f1037e6eae0) + local `test_emits_CalldataBatchRegistered`
- [x] Verify `registerCalldataBatch` stores the content hash in `registered` mapping — [Sepolia step 5](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `test_stores_content_hash_in_registered`
- [x] Verify `exposeMessage` reverts with `NotRegistered` for unregistered batch hashes — [Sepolia step 8](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `test_exposeMessage_reverts_NotRegistered`
- [x] Verify `exposeMessage` reverts with `AlreadyExposed` on double-exposure — [Sepolia step 8](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `test_exposeMessage_reverts_AlreadyExposed`
- [x] Verify `exposeMessage` emits `MessageExposed` with correct indexed fields — [Sepolia tx `9e3334...`](https://sepolia.etherscan.io/tx/0x9e33346cf171fbe511e7b7638c2fccd1126e513f4705b082b559be16dfbf4314) + local `test_exposeMessage_emits_MessageExposed`
- [x] Verify `isExposed` returns `False` before exposure and `True` after — [Sepolia step 8](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `test_isExposed_false_before_exposure` / `test_isExposed_true_after_exposure`
- [x] Verify `computeMessageId` matches `keccak256(author || nonce || contentHash)` — [Sepolia step 8](https://github.com/vbuterin/SocialBlobs/pull/13#issuecomment-3986187820) + local `test_computeMessageId_matches_keccak`
- [x] Verify existing `decoder.vy` and `signature_registry.vy` are unmodified — local `TestExistingContractsUnmodified` (2 tests)
- [ ] Verify `registerBlobBatch` emits both `BlobSegmentDeclared` and `BlobBatchRegistered` events — requires EIP-4844 blob transaction (BSS validation logic verified via revert tests)