### PR TITLE
fix: include nonce in BLS signing payload (closes #2)

### DIFF
--- a/blob_encoder.py
+++ b/blob_encoder.py
@@ -22,6 +22,15 @@ from data_signer import aggregate_signatures
 MessageTuple = Tuple[bytes | str, int, bytes]
 
 
+def signing_payload(nonce: int, content: bytes) -> bytes:
+    """Build the signing payload: nonce (8 bytes big-endian) || content.
+
+    BLS signatures must cover the nonce to prevent a blob submitter from
+    tampering with message ordering.  See issue #2.
+    """
+    return nonce.to_bytes(8, "big") + content
+
+
 def _parse_sender(sender: bytes | str) -> bytes:
     if isinstance(sender, str):
         if not sender.startswith("0x"):
@@ -82,7 +91,7 @@ if __name__ == "__main__":
         b"the quick brown fox jumps over the yellow dog"
     ]
     signers  = [Signer.generate() for _ in range(3)]
-    sigs     = [s.sign(c) for s, c in zip(signers, contents)]
+    sigs     = [s.sign(signing_payload(n, c)) for s, n, c in zip(signers, nonces, contents)]
 
     blob = encode_blob(list(zip(senders, nonces, contents)), sigs, lambda x: x)
     print(f"Generated blob: {len(blob)} bytes")

--- a/test.py
+++ b/test.py
@@ -15,7 +15,7 @@ from web3.providers.eth_tester import EthereumTesterProvider
 from vyper import compile_code
 
 from data_signer import Signer, aggregate_signatures
-from blob_encoder import encode_blob
+from blob_encoder import encode_blob, signing_payload
 from bpe_encode import deploy_decoder, build_10bit_dict_from_corpus, encode_msg
 
 
@@ -93,15 +93,15 @@ msg_contents = [
     b"without going through a financial institution"
 ]
 n = len(msg_contents)
+nonces: List[int] = list(range(n))
 
 signers   = [Signer.generate() for _ in range(n)]
-sigs      = [s.sign(m) for s, m in zip(signers, msg_contents)]
+sigs      = [s.sign(signing_payload(nc, m)) for s, nc, m in zip(signers, nonces, msg_contents)]
 agg_sig   = aggregate_signatures(sigs)
 
 # Each BLS signer uses a distinct Ethereum account so their public keys are
 # stored at different addresses in the registry mapping.
 signer_accounts = accounts[1:n + 1]
-nonces: List[int] = list(range(n))
 message_tuples: List[Tuple[str, int, bytes]] = list(
     zip(signer_accounts, nonces, msg_contents)
 )
@@ -154,7 +154,7 @@ for msg in msg_contents:
 # ---------------------------------------------------------------------------
 
 owners   = list(signer_accounts)
-messages = list(msg_contents)
+messages = [signing_payload(n, m) for n, m in zip(nonces, msg_contents)]
 
 assert registry.functions.verifyAggregated(owners, messages, agg_sig).call(), \
     "verifyAggregated rejected a valid aggregate signature"
@@ -170,7 +170,7 @@ assert not bad_result, "verifyAggregated accepted a tampered signature"
 print("✅ Tampered signature correctly rejected")
 
 # Negative check: wrong message must be rejected.
-wrong_messages = [b"wrong message"] + messages[1:]
+wrong_messages = [signing_payload(0, b"wrong message")] + messages[1:]
 try:
     wrong_result = registry.functions.verifyAggregated(owners, wrong_messages, agg_sig).call()
 except Exception:


### PR DESCRIPTION
## Summary

Fixes #2 — nonces were not covered by BLS signatures, allowing a blob submitter to replay or reorder messages without invalidating the aggregate signature.

## Changes

- **`blob_encoder.py`**: Add `signing_payload(nonce, content)` → `nonce (8B big-endian) || content`. All BLS signatures now cover the nonce.
- **`test.py`**: Sign over `signing_payload(nonce, content)` instead of bare `content`. Verification passes `nonce || content` to `verifyAggregated`.

## Signing payload format

```
signing_payload = nonce.to_bytes(8, "big") + content
```

The nonce is the 8-byte big-endian encoding already present in the blob body (`sender (20B) | nonce (8B) | contents`). Including it in the signed message means:
- A blob submitter **cannot** replay old messages with new nonces
- A blob submitter **cannot** reorder nonces across messages
- On-chain verification via `verifyAggregated(owners, [nonce||content, ...], agg_sig)` cryptographically enforces nonce integrity

## Why not include sender?

The sender is already implicitly authenticated via key registration — each BLS key is bound to exactly one Ethereum address in the registry. Including the nonce is the minimal fix that closes the attack vector.

## No contract changes needed

`signature_registry.vy`'s `verifyAggregated` already accepts arbitrary `Bytes[1024]` messages. The change is purely in what bytes are signed and passed to verification — no Vyper contract modifications required.

## Test results

```
✅ Decoder test passed
✅ Aggregate signature verified on-chain
✅ Tampered signature correctly rejected
✅ Wrong message correctly rejected
✅ All tests passed
```