### PR TITLE
Switch to MIT license and rewrite README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,121 +1,21 @@
-Creative Commons Legal Code
+MIT License
 
-CC0 1.0 Universal
+Copyright (c) 2025 Vitalik Buterin and contributors
 
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Statement of Purpose
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,112 @@
-# SocialBlobs
+<h1 align="center">SocialBlobs</h1>
 
-An implementation of an encoder/decoder and BLS signature verifier for https://github.com/ethereum/ERCs/pull/1578, a minimalistic "social on Ethereum blobs/calldata" protocol.
+<p align="center">
+  <strong>Blob-Authenticated Messaging for Ethereum</strong>
+  <br />
+  Reference implementation of <a href="https://github.com/ethereum/ERCs/pull/1578">ERC-8180</a> (BAM) and <a href="https://github.com/ethereum/ERCs/pull/1577">ERC-8179</a> (BSS)
+</p>
 
-* `signature_registry.vy` implements a signature registry, which allows addresses to register their BLS keys, and also implements a BLS signature aggregate verifier
-* `decoder.vy` implements a blob decompressor, which deserializes a blob (could be literal blob contents or calldata) into tuples of (sender, nonce, message), and uses a basic compression algorithm (with corpus.txt as the dictionary source) to dompress the message
-* `hash_to_point_test.py` tests the hash-to-point part of the BLS signature verifier (by far the hardest part to get right in my experience)
-* `bpe_encode.py` does an end-to-end test of the compression and decompression
-* `test.py` tests everything
+<p align="center">
+  <a href="https://github.com/vbuterin/SocialBlobs/actions"><img src="https://github.com/vbuterin/SocialBlobs/actions/workflows/test.yml/badge.svg" alt="CI" /></a>
+  <img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+" />
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT" /></a>
+  <img src="https://img.shields.io/badge/tests-144%2B-brightgreen" alt="Tests 144+" />
+</p>
+
+> **Warning** — This is an experimental research project. The contracts and tooling are unaudited. Do not use in production without independent review.
+
+**Quick links:** [Quick Start](#quick-start) | [Architecture](#architecture) | [Project Structure](#project-structure) | [API Reference](#related-standards) | [Contributing](CONTRIBUTING.md)
+
+---
+
+## What is BAM?
+
+Blob-Authenticated Messaging (BAM) lets you publish signed messages on Ethereum at blob-data costs. Messages are compressed with a BPE dictionary, signed with BLS12-381 aggregate signatures, packed into EIP-4844 blobs, and verified on-chain via the EIP-2537 BLS precompiles.
+
+The result is a minimalistic "social on Ethereum" protocol: authenticated, censorship-resistant messaging that piggybacks on Ethereum's data availability layer.
+
+## Features
+
+- **BPE compression** -- 12-bit dictionary (4,096 codes) learned from a natural-language corpus, achieving 2-4x compression on typical messages
+- **BLS12-381 signatures** -- Keys on G1, signatures on G2, with aggregate verification supporting up to 64 signers per blob
+- **On-chain decoding** -- Vyper contracts decode blobs and verify signatures using EIP-2537 precompiles
+- **ERC-8180 compliant** -- Full BAM Core, Decoder, Signature Registry, and Exposer interfaces
+- **Proof of possession** -- Rogue-key attack prevention via PoP during key registration
+- **Sepolia deployed** -- Live deployment on Ethereum Sepolia testnet ([deployment details](sepolia_deployment.txt))
+
+## Quick Start
+
+```bash
+git clone https://github.com/vbuterin/SocialBlobs.git
+cd SocialBlobs
+pip install -r requirements.txt
+make test
+```
+
+Or run the full test suite directly:
+
+```bash
+# Legacy end-to-end test
+python test.py
+
+# Full pytest suite (144+ tests)
+pytest -v
+
+# Individual test modules
+pytest test_bpe_encode.py -v        # Compression / decompression
+pytest test_blob_encoder.py -v      # Blob encoding format
+pytest test_data_signer.py -v       # BLS signing
+pytest test_decoder.py -v           # On-chain decoding
+pytest test_signature_registry.py -v  # BLS registry
+pytest test_e2e.py -v               # Full pipeline integration
+pytest test_erc_interfaces.py -v    # ERC interface compliance
+```
+
+## Architecture
+
+```
+User message --> BPE compress --> BLS sign --> Blob encode --> EIP-4844 blob tx
+                                                                    |
+                                                                    v
+On-chain:  registerBlobBatch()  -->  decoder.decode()  -->  signature_registry.verify()
+                                                                    |
+                                                                    v
+                                                          exposer.getMessages()
+```
+
+The pipeline has three stages:
+
+1. **Off-chain encoding** -- Messages are BPE-compressed, BLS-signed, and packed into 128 KiB blobs.
+2. **Blob submission** -- Blobs are submitted via EIP-4844 blob-carrying transactions.
+3. **On-chain verification** -- Contracts decode the blob, look up registered BLS public keys, and verify aggregate signatures.
+
+## Project Structure
+
+| File | Description |
+|------|-------------|
+| `bam_core.vy` | BAM Core contract -- blob batch registration and message storage |
+| `decoder.vy` | On-chain BPE decompressor for blob / calldata payloads |
+| `signature_registry.vy` | BLS12-381 public key registry with PoP and aggregate verification |
+| `exposer.vy` | Read-only exposer interface for querying decoded messages |
+| `bpe_encode.py` | BPE tokenizer -- dictionary training and encode/decode |
+| `blob_encoder.py` | Blob packing -- serializes compressed messages into 128 KiB blobs |
+| `data_signer.py` | BLS signing utilities -- key generation, signing, aggregation |
+| `deploy_sepolia.py` | Deployment script for Sepolia testnet |
+| `conftest.py` | Shared pytest fixtures (Vyper compilation, contract deployment) |
+| `corpus.txt` | Natural-language corpus for BPE dictionary training |
+| `test*.py` | Test suite -- 144+ tests covering all modules |
+
+## Related Standards
+
+- [ERC-8180](https://github.com/ethereum/ERCs/pull/1578) -- Blob-Authenticated Messaging (BAM)
+- [ERC-8179](https://github.com/ethereum/ERCs/pull/1577) -- Blob Segment Subscription (BSS)
+- [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) -- Shard Blob Transactions
+- [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) -- BLS12-381 curve operations precompiles
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, test commands, and the PR process.
+
+## License
+
+[MIT](LICENSE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "socialblobs"
 version = "0.1.0"
 description = "Blob-authenticated messaging (ERC-8180) — reference implementation"
 requires-python = ">=3.10"
-license = {text = "CC0-1.0"}
+license = {text = "MIT"}
 dependencies = [
     "py_ecc>=7.0.0",
     "web3>=7.0.0",


### PR DESCRIPTION
## Summary

- Replace CC0-1.0 license with MIT for better software ecosystem compatibility
- Rewrite README from 10-line description to professional open-source format
- Update pyproject.toml license field

Closes #18, closes #19

## Changes

**LICENSE** — MIT License (copyright 2025 Vitalik Buterin and contributors)

**README.md** — Complete rewrite:
- Centered title with ERC-8180/8179 links
- Badges (CI, Python 3.10+, MIT, 144+ tests)
- "What is BAM?" section
- Features list (BPE compression, BLS signatures, on-chain decoding, Sepolia deployment)
- Quick Start
- Architecture pipeline diagram
- Project structure table
- Related standards links

**pyproject.toml** — License field updated to MIT

## Test plan

- [x] No source files modified — all existing tests pass unchanged
- [x] CI green on Python 3.10, 3.11, 3.12
- [x] License renders correctly on GitHub
- [x] README renders correctly on GitHub