### PR TITLE
fix: align bam_provider with 12-bit dictionary after Farcaster corpus merge

### DIFF
--- a/bam_provider.py
+++ b/bam_provider.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from data_signer import Signer, aggregate_signatures, verify_signature
 from blob_encoder import encode_blob, signing_payload
-from bpe_encode import build_10bit_dict_from_corpus, encode_msg
+from bpe_encode import build_12bit_dict_from_corpus, encode_msg
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +166,7 @@ class DefaultBAMProvider(BAMProvider):
     def __init__(self, corpus_path: str = "corpus.txt"):
         self._corpus_path = corpus_path
         self._token_to_code, self._dict_bytes, self._dict_offs, self._dict_len = (
-            build_10bit_dict_from_corpus(corpus_path)
+            build_12bit_dict_from_corpus(corpus_path)
         )
         self._signers: Dict[str, Signer] = {}
 
@@ -251,8 +251,8 @@ class DefaultBAMProvider(BAMProvider):
 
     def decompress(self, data: bytes) -> bytes:
         """Pure-Python BPE decompression (mirrors decoder.vy logic)."""
-        if len(data) % 5 != 0:
-            raise ValueError("encoded data not 5-byte aligned")
+        if len(data) % 3 != 0:
+            raise ValueError("encoded data not 3-byte aligned")
 
         # Build code-to-token reverse lookup
         code_to_token: dict[int, bytes] = {}
@@ -260,13 +260,11 @@ class DefaultBAMProvider(BAMProvider):
             code_to_token[code] = token
 
         out = bytearray()
-        for i in range(0, len(data), 5):
-            word = int.from_bytes(data[i:i + 5], "big")
+        for i in range(0, len(data), 3):
+            word = int.from_bytes(data[i:i + 3], "big")
             codes = [
-                (word >> 30) & 0x3FF,
-                (word >> 20) & 0x3FF,
-                (word >> 10) & 0x3FF,
-                word & 0x3FF,
+                (word >> 12) & 0xFFF,
+                word & 0xFFF,
             ]
             for code in codes:
                 if code == 0:
@@ -279,7 +277,7 @@ class DefaultBAMProvider(BAMProvider):
     def get_dictionary(self) -> DictInfo:
         return DictInfo(
             num_codes=len(self._token_to_code),
-            bits_per_code=10,
+            bits_per_code=12,
             dict_bytes_size=len(self._dict_bytes),
             corpus_path=self._corpus_path,
         )

--- a/test_rpc_server.py
+++ b/test_rpc_server.py
@@ -64,7 +64,7 @@ class TestDispatcher:
     def test_get_dictionary(self, dispatcher):
         result = dispatcher.dispatch("bam_getDictionary", None)
         assert result["numCodes"] >= 1024
-        assert result["bitsPerCode"] == 10
+        assert result["bitsPerCode"] == 12
         assert result["dictBytesSize"] > 0
 
     def test_compress_decompress(self, dispatcher):
@@ -105,7 +105,7 @@ class TestHTTPServer:
     def test_get_dictionary_via_client(self, client):
         result = client.get_dictionary()
         assert result["numCodes"] >= 1024
-        assert result["bitsPerCode"] == 10
+        assert result["bitsPerCode"] == 12
 
     def test_compress_via_client(self, client):
         result = client.compress(b"hello world")
@@ -182,5 +182,5 @@ class TestDefaultProvider:
     def test_dict_info(self, provider):
         info = provider.get_dictionary()
         assert info.num_codes >= 1024
-        assert info.bits_per_code == 10
+        assert info.bits_per_code == 12
         assert info.dict_bytes_size > 0


### PR DESCRIPTION
## Summary

PR #24 (Farcaster corpus) introduced `bam_provider.py` that still uses 10-bit encoding (5-byte alignment, `0x3FF` masks) while `bpe_encode.py` was already upgraded to 12-bit in PR #22 (3-byte alignment, `0xFFF` masks).

This mismatch causes `decompress()` to fail with `"encoded data not 5-byte aligned"` on 3-byte-aligned compressed output, breaking 3 CI tests:
- `TestDispatcher::test_compress_decompress`
- `TestHTTPServer::test_decompress_via_client`  
- `TestDefaultProvider::test_compress_roundtrip`

## Changes

**`bam_provider.py`:**
- Import `build_12bit_dict_from_corpus` (was `build_10bit_dict_from_corpus`)
- `decompress()`: 3-byte words with 2×12-bit codes (was 5-byte words with 4×10-bit)
- `get_dictionary()`: `bits_per_code=12` (was `10`)

**`test_rpc_server.py`:**
- Update `bitsPerCode` assertions from `10` → `12`

## Test plan

- [x] `test_compress_decompress` passes locally
- [x] `test_decompress_via_client` passes locally
- [x] `test_compress_roundtrip` passes locally
- [x] All dict metadata assertions updated and pass